### PR TITLE
Make setup.py use env to find python3 interpreter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Part of mlat-client - an ADS-B multilateration client.
 # Copyright 2015, Oliver Jowett <oliver@mutability.co.uk>


### PR DESCRIPTION
This makes it possible to run `setup.py` in environments where `python3` is not in `/usr/bin`; for example, when it's installed on OS X via Homebrew.